### PR TITLE
Feature: Add support for using 'assert' syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,14 +124,17 @@ Test file:
 
 ```js
 // __tests__/index.js
-import { use, expect } from "chai";
+import { use, expect, assert } from "chai";
 import { matchSnapshot } from "chai-karma-snapshot";
 import { test } from "../src/index.js";
 use(matchSnapshot);
 
 describe("src/index.js", () => {
   it("check snapshot", () => {
+    // 'expect' syntax:
     expect(test()).to.matchSnapshot();
+    // 'assert' syntax:
+    assert.matchSnapshot(test());
   });
 });
 ```

--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -3,7 +3,10 @@
 declare global {
   namespace Chai {
     interface Assertion {
-      matchSnapshot(lang?: string, update?: boolean): Assertion;
+      matchSnapshot(lang?: any, update?: boolean): Assertion;
+    }
+    interface AssertStatic {
+      matchSnapshot(lang?: any, update?: boolean): Assertion;
     }
   }
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,7 +36,15 @@ function matchSnapshot(chai, utils) {
   var context = window.__mocha_context__;
   var snapshotState = window.__snapshot__;
 
-  utils.addMethod(chai.Assertion.prototype, "matchSnapshot", function (lang, update) {
+  utils.addMethod(chai.Assertion.prototype, "matchSnapshot", aMethodForExpect);
+  chai.assert.matchSnapshot = aMethodForAssert;
+
+  function aMethodForAssert(lang, update, msg) {
+    // This basically wraps the 'expect' version of the assertion to allow using 'assert' syntax.
+    return new chai.Assertion(lang, update, msg).to.matchSnapshot();
+  }
+
+  function aMethodForExpect(lang, update) {
     var obj = serialize(chai.util.flag(this, "object"));
     var path = snapshotPath(context.runnable);
     var index = context.index++;
@@ -57,7 +65,7 @@ function matchSnapshot(chai, utils) {
         }
       }
     }
-  });
+  }
 }
 
 exports.addSerializer = addSerializer;


### PR DESCRIPTION
Hi!

I noticed I didn't seem to be able to use the `assert` syntax so I made some changes that expand the functionality of the library. If there's anything else you would like to see done before this can be merged I'd be happy to tweak it - I just think it would be great to add this feature!

Thanks.