### PR TITLE
Remove undefined prettyFormat.plugins.HTMLElement

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -6,7 +6,6 @@ var prettyFormat = require("pretty-format");
  * Serialization code were copied from Jest.
  */
 var serializationPlugins = [
-  prettyFormat.plugins.HTMLElement,
   prettyFormat.plugins.ReactElement,
   prettyFormat.plugins.ReactTestComponent,
 ].concat(prettyFormat.plugins.Immutable);

--- a/lib/index.js
+++ b/lib/index.js
@@ -6,6 +6,7 @@ var prettyFormat = require("pretty-format");
  * Serialization code were copied from Jest.
  */
 var serializationPlugins = [
+  prettyFormat.plugins.DOMElement,
   prettyFormat.plugins.ReactElement,
   prettyFormat.plugins.ReactTestComponent,
 ].concat(prettyFormat.plugins.Immutable);


### PR DESCRIPTION
Hi,

it seems that `HTMLElement` plugin has been removed. When I tried to use this library for snapshotting the tests failed with message:
```
    TypeError: Cannot read property 'test' of undefined
        at findPlugin (test/karma.entry.js:377764:22)
        at prettyFormat (test/karma.entry.js:377890:20)
        at serialize (test/karma.entry.js:373744:10)
        at Proxy.aMethodForExpect (test/karma.entry.js:373773:15)
        at Proxy.methodWrapper (test/karma.entry.js:365735:25)
        at Context.<anonymous> (test/karma.entry.js:364254:43)
        at Test.Runnable.run (node_modules/karma-mocha-snapshot/lib/adapter.js:15:17)
```

Do you know if just removing `prettyFormat.plugins.HTMLElement` is the correct action? It at least makes my tests not fail. 