### PR TITLE
Feature: Support hooks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -50,8 +50,15 @@ function matchSnapshot(chai, utils) {
 
   function aMethodForExpect(lang, update) {
     var obj = serialize(chai.util.flag(this, "object"));
-    var path = snapshotPath(context.runnable);
     var index = context.index++;
+    var path;
+
+    // For a hook, use the currentTest for path
+    if (context.runnable.type === "hook") {
+        path = snapshotPath(context.runnable.ctx.currentTest);
+    } else {
+        path = snapshotPath(context.runnable);
+    }
 
     if (update || snapshotState.update) {
       snapshotState.set(path, index, obj, lang);


### PR DESCRIPTION
The path used for hooks doesn't seem to use the path of the test which ran. This update allows hooks to be used to match snapshots. This is useful for making assertions for snapshots in an `afterEach` hook as follows:

```
afterEach(function() {
   expect(somethingCollectedDuringEachTest).to.matchSnapshot();
});
```